### PR TITLE
Improve dark mode styling, add theme toggle & hamburger menu

### DIFF
--- a/closedose-nfc/apps/web/app.js
+++ b/closedose-nfc/apps/web/app.js
@@ -1,0 +1,389 @@
+/* ================================================================
+   CAPPY — Application JavaScript
+   Theme: System / Day (light) / Night (dark)
+     - Stored in localStorage as 'cappy-theme'
+     - Applied to <html data-theme="..."> immediately on load
+     - System mode removes data-theme and relies on @media CSS
+   ================================================================ */
+
+(function () {
+  'use strict';
+
+  /* ── Theme ──────────────────────────────────────────────────── */
+  const STORAGE_KEY = 'cappy-theme';
+  const VALID_THEMES = ['system', 'light', 'dark'];
+
+  function getSavedTheme() {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      return VALID_THEMES.includes(saved) ? saved : 'system';
+    } catch {
+      return 'system';
+    }
+  }
+
+  function applyTheme(theme) {
+    const html = document.documentElement;
+    if (theme === 'system') {
+      html.removeAttribute('data-theme');
+    } else {
+      html.setAttribute('data-theme', theme);
+    }
+
+    // Update all theme button sets
+    document.querySelectorAll('[data-theme-value]').forEach(btn => {
+      const isActive = btn.dataset.themeValue === theme;
+      btn.classList.toggle('active', isActive);
+      btn.setAttribute('aria-pressed', String(isActive));
+    });
+
+    // Persist
+    try { localStorage.setItem(STORAGE_KEY, theme); } catch { /* noop */ }
+  }
+
+  // Apply immediately to avoid flash of wrong theme
+  applyTheme(getSavedTheme());
+
+  /* ── DOM Ready ──────────────────────────────────────────────── */
+  document.addEventListener('DOMContentLoaded', () => {
+
+    /* Theme buttons (all contexts: desktop strip + hamburger menu) */
+    document.querySelectorAll('[data-theme-value]').forEach(btn => {
+      btn.addEventListener('click', () => applyTheme(btn.dataset.themeValue));
+    });
+
+    /* Keep in sync with OS changes when in System mode */
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    mq.addEventListener('change', () => {
+      if (getSavedTheme() === 'system') applyTheme('system');
+    });
+
+    /* ── Hamburger / Mobile Menu ──────────────────────────────── */
+    const hamburger   = document.getElementById('hamburger');
+    const menuPanel   = document.getElementById('mobileMenu');
+    const backdrop    = document.getElementById('menuBackdrop');
+    const menuClose   = document.getElementById('menuClose');
+
+    function openMenu() {
+      menuPanel.classList.add('open');
+      backdrop.classList.add('open');
+      hamburger.setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
+      menuClose.focus();
+    }
+
+    function closeMenu() {
+      menuPanel.classList.remove('open');
+      backdrop.classList.remove('open');
+      hamburger.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+      hamburger.focus();
+    }
+
+    hamburger?.addEventListener('click', openMenu);
+    menuClose?.addEventListener('click', closeMenu);
+    backdrop?.addEventListener('click', closeMenu);
+
+    // Close menu on nav link click
+    document.querySelectorAll('.menu-link').forEach(link => {
+      link.addEventListener('click', closeMenu);
+    });
+
+    // Keyboard: Escape closes menu
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && menuPanel?.classList.contains('open')) {
+        closeMenu();
+      }
+    });
+
+    // Trap focus inside menu when open
+    menuPanel?.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+      const focusable = Array.from(
+        menuPanel.querySelectorAll('a, button, input, select, [tabindex]:not([tabindex="-1"])')
+      ).filter(el => !el.disabled);
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last  = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault(); last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault(); first.focus();
+      }
+    });
+
+    /* ── Header scroll shadow ──────────────────────────────────── */
+    const header = document.getElementById('header');
+    const onScroll = () => {
+      header?.classList.toggle('scrolled', window.scrollY > 8);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    /* ── Unit toggle (kg / lbs) ───────────────────────────────── */
+    let currentUnit = 'kg';
+    const weightInput = document.getElementById('weightInput');
+
+    document.querySelectorAll('.unit-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const newUnit = btn.dataset.unit;
+        if (newUnit === currentUnit) return;
+
+        // Convert existing value
+        const val = parseFloat(weightInput.value);
+        if (!isNaN(val) && val > 0) {
+          weightInput.value = newUnit === 'lbs'
+            ? (val * 2.20462).toFixed(1)
+            : (val / 2.20462).toFixed(2);
+        }
+
+        currentUnit = newUnit;
+        document.querySelectorAll('.unit-btn').forEach(b => {
+          b.classList.toggle('active', b.dataset.unit === newUnit);
+        });
+      });
+    });
+
+    /* ── Dose Calculator ──────────────────────────────────────── */
+    const calcBtn   = document.getElementById('calcBtn');
+    const medSelect = document.getElementById('medSelect');
+    const resultBox = document.getElementById('resultBox');
+    const resultDose = document.getElementById('resultDose');
+    const resultMeta = document.getElementById('resultMeta');
+
+    calcBtn?.addEventListener('click', () => {
+      const rawWeight = parseFloat(weightInput?.value);
+      const selected  = medSelect?.options[medSelect.selectedIndex];
+
+      // Validation
+      if (!rawWeight || rawWeight <= 0) {
+        shakeElement(weightInput);
+        weightInput?.focus();
+        return;
+      }
+      if (!medSelect?.value) {
+        shakeElement(medSelect);
+        medSelect?.focus();
+        return;
+      }
+
+      // Convert to kg if needed
+      const weightKg = currentUnit === 'lbs' ? rawWeight / 2.20462 : rawWeight;
+
+      const dosePerKg = parseFloat(selected.dataset.dose);
+      const maxDose   = parseFloat(selected.dataset.max);
+      const unit      = selected.dataset.unit;
+      const interval  = selected.dataset.interval;
+
+      const calculated = weightKg * dosePerKg;
+      const finalDose  = Math.min(calculated, maxDose);
+      const capped     = calculated > maxDose;
+
+      resultDose.textContent = `${finalDose.toFixed(1)} ${unit}`;
+      resultMeta.textContent = `Based on ${weightKg.toFixed(1)} kg · ${interval}` +
+        (capped ? ` · dose capped at ${maxDose} ${unit} maximum` : '');
+
+      resultBox.hidden = false;
+      resultBox.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+
+    // Recalculate on Enter in weight field
+    weightInput?.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') calcBtn?.click();
+    });
+
+    /* ── NFC Scan (simulated) ─────────────────────────────────── */
+    const nfcBtn       = document.getElementById('nfcBtn');
+    const verifyStatus = document.getElementById('verifyStatus');
+
+    nfcBtn?.addEventListener('click', async () => {
+      // Check Web NFC API availability
+      if ('NDEFReader' in window) {
+        await scanNFC();
+      } else {
+        simulateScan();
+      }
+    });
+
+    async function scanNFC() {
+      nfcBtn.disabled = true;
+      nfcBtn.textContent = 'Scanning…';
+      setVerifyStatus('info', 'Hold your device near the cap…');
+
+      try {
+        const reader = new window.NDEFReader();
+        await reader.scan();
+        reader.onreading = ({ serialNumber, message }) => {
+          const records = message.records;
+          const urlRecord = records.find(r => r.recordType === 'url');
+          setVerifyStatus('success', `✓ Cap verified — Serial ${serialNumber.slice(-8).toUpperCase()}`);
+          nfcBtn.disabled = false;
+          nfcBtn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg> Scan Cap';
+        };
+        reader.onerror = () => {
+          setVerifyStatus('error', '✗ NFC read error. Try again.');
+          resetNfcBtn();
+        };
+      } catch (err) {
+        if (err.name === 'NotAllowedError') {
+          setVerifyStatus('error', 'NFC permission denied. Check browser settings.');
+        } else {
+          simulateScan();
+        }
+        resetNfcBtn();
+      }
+    }
+
+    function simulateScan() {
+      nfcBtn.disabled = true;
+      setVerifyStatus('info', 'Scanning…');
+
+      setTimeout(() => {
+        setVerifyStatus('success', '✓ Cap verified — Signature valid (demo mode)');
+        resetNfcBtn();
+      }, 1800);
+    }
+
+    function resetNfcBtn() {
+      nfcBtn.disabled = false;
+      nfcBtn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg> Scan Cap';
+    }
+
+    function setVerifyStatus(type, message) {
+      if (!verifyStatus) return;
+      verifyStatus.textContent = message;
+      verifyStatus.className = 'verify-status';
+      if (type !== 'info') verifyStatus.classList.add(type);
+    }
+
+    /* ── Cappy button easter egg ─────────────────────────────── */
+    const cappyBtn = document.getElementById('cappyBtn');
+    const greetings = [
+      'Hi there! 👋', "Let's check your meds!", 'Tap to verify your cap!',
+      'Staying healthy? Good job! 💊', 'Time for your dose?', "I'm Cappy, your med pal!"
+    ];
+    let greetIdx = 0;
+
+    cappyBtn?.addEventListener('click', () => {
+      const msg = greetings[greetIdx % greetings.length];
+      greetIdx++;
+
+      // Show floating toast
+      showToast(msg);
+    });
+
+    /* ── Toast notification ──────────────────────────────────── */
+    function showToast(message) {
+      const existing = document.getElementById('cappy-toast');
+      if (existing) existing.remove();
+
+      const toast = document.createElement('div');
+      toast.id = 'cappy-toast';
+      toast.setAttribute('role', 'status');
+      toast.setAttribute('aria-live', 'polite');
+      toast.textContent = message;
+      toast.style.cssText = `
+        position: fixed;
+        bottom: calc(env(safe-area-inset-bottom, 0px) + 1.5rem);
+        left: 50%;
+        transform: translateX(-50%) translateY(20px);
+        background: var(--surface);
+        color: var(--text);
+        border: 1px solid var(--border);
+        padding: 0.75rem 1.5rem;
+        border-radius: 9999px;
+        font-size: 0.9rem;
+        font-weight: 600;
+        box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+        z-index: 9999;
+        opacity: 0;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+        white-space: nowrap;
+        max-width: calc(100vw - 2rem);
+        text-align: center;
+        font-family: inherit;
+      `;
+      document.body.appendChild(toast);
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          toast.style.opacity = '1';
+          toast.style.transform = 'translateX(-50%) translateY(0)';
+        });
+      });
+
+      setTimeout(() => {
+        toast.style.opacity = '0';
+        toast.style.transform = 'translateX(-50%) translateY(10px)';
+        setTimeout(() => toast.remove(), 250);
+      }, 2500);
+    }
+
+    /* ── Smooth scroll for hash links ────────────────────────── */
+    document.querySelectorAll('a[href^="#"]').forEach(link => {
+      link.addEventListener('click', (e) => {
+        const target = document.querySelector(link.getAttribute('href'));
+        if (target) {
+          e.preventDefault();
+          const top = target.getBoundingClientRect().top + window.scrollY
+                    - parseInt(getComputedStyle(document.documentElement)
+                        .getPropertyValue('--header-h') || '64', 10) - 8;
+          window.scrollTo({ top, behavior: 'smooth' });
+        }
+      });
+    });
+
+    /* ── Active nav link on scroll ──────────────────────────── */
+    const sections = document.querySelectorAll('section[id]');
+    const navLinks  = document.querySelectorAll('.nav-link');
+
+    const observerOpts = {
+      rootMargin: `-${parseInt(getComputedStyle(document.documentElement)
+        .getPropertyValue('--header-h') || '64', 10) + 20}px 0px -50% 0px`
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          navLinks.forEach(link => {
+            link.classList.toggle('active', link.getAttribute('href') === `#${entry.target.id}`);
+          });
+        }
+      });
+    }, observerOpts);
+
+    sections.forEach(s => observer.observe(s));
+
+  }); // end DOMContentLoaded
+
+  /* ── Utility: shake animation on invalid input ─────────────── */
+  function shakeElement(el) {
+    if (!el) return;
+    el.style.animation = 'none';
+    el.offsetHeight; // reflow
+    el.style.animation = 'shake 0.35s ease';
+    el.addEventListener('animationend', () => { el.style.animation = ''; }, { once: true });
+  }
+
+  // Inject shake keyframes once
+  const style = document.createElement('style');
+  style.textContent = `
+    @keyframes shake {
+      0%, 100% { transform: translateX(0); }
+      20%       { transform: translateX(-5px); }
+      40%       { transform: translateX(5px); }
+      60%       { transform: translateX(-4px); }
+      80%       { transform: translateX(4px); }
+    }
+    .nav-link.active {
+      color: var(--clr-accent) !important;
+    }
+    .header.scrolled {
+      box-shadow: 0 1px 8px rgba(0,0,0,0.12);
+    }
+    .verify-status.info {
+      color: var(--text-secondary);
+    }
+  `;
+  document.head.appendChild(style);
+
+})();

--- a/closedose-nfc/apps/web/assets/images/README.md
+++ b/closedose-nfc/apps/web/assets/images/README.md
@@ -1,0 +1,14 @@
+# Assets — Images
+
+Place `cappy_circle.png` in this directory. It is referenced site-wide as:
+
+```
+assets/images/cappy_circle.png
+```
+
+A vector fallback (`cappy_circle.svg`) is included for development. Replace it with the final `cappy_circle.png` for production.
+
+**Recommended specs:**
+- Format: PNG with transparent background
+- Size: 400×400 px minimum (displayed at up to 160px)
+- Shape: circular crop already applied to the image (not via CSS)

--- a/closedose-nfc/apps/web/assets/images/cappy_circle.svg
+++ b/closedose-nfc/apps/web/assets/images/cappy_circle.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0284c7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:0.25" />
+      <stop offset="100%" style="stop-color:#ffffff;stop-opacity:0" />
+    </linearGradient>
+  </defs>
+  <!-- Circle background -->
+  <circle cx="100" cy="100" r="100" fill="url(#bg)"/>
+  <!-- Shine overlay -->
+  <circle cx="100" cy="100" r="100" fill="url(#shine)"/>
+  <!-- Cap icon shape -->
+  <ellipse cx="100" cy="82" rx="46" ry="12" fill="rgba(255,255,255,0.9)"/>
+  <rect x="66" y="82" width="68" height="44" rx="6" fill="rgba(255,255,255,0.85)"/>
+  <!-- Cap lid highlight -->
+  <ellipse cx="100" cy="82" rx="34" ry="7" fill="rgba(255,255,255,0.4)"/>
+  <!-- Subtle cross / plus pill mark -->
+  <rect x="96" y="92" width="8" height="24" rx="4" fill="rgba(14,165,233,0.7)"/>
+  <rect x="88" y="100" width="24" height="8" rx="4" fill="rgba(14,165,233,0.7)"/>
+  <!-- Bottom text area -->
+  <text x="100" y="155" font-family="-apple-system, sans-serif" font-size="18" font-weight="700" fill="white" text-anchor="middle" opacity="0.95">Cappy</text>
+</svg>

--- a/closedose-nfc/apps/web/index.html
+++ b/closedose-nfc/apps/web/index.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Cappy — Smart NFC medication tracking with weight-based dosing guides and cap verification.">
+  <meta name="theme-color" content="#0ea5e9" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)">
+  <title>Cappy — Smart Medication Tracking</title>
+  <link rel="stylesheet" href="styles.css">
+  <!-- Favicon: use PNG if available, fall back to SVG -->
+  <link rel="icon" href="assets/images/cappy_circle.png" type="image/png">
+  <link rel="icon" href="assets/images/cappy_circle.svg" type="image/svg+xml">
+</head>
+<body>
+
+  <!-- ═══════════════════════════════════════════
+       HEADER
+  ═══════════════════════════════════════════ -->
+  <header class="header" id="header">
+    <div class="header-inner container">
+      <a href="#home" class="logo" aria-label="Cappy home">
+        <img src="assets/images/cappy_circle.png" alt="" class="logo-img" aria-hidden="true" onerror="this.style.display='none'">
+        <span class="logo-wordmark">Cappy</span>
+      </a>
+
+      <nav class="nav-desktop" aria-label="Primary navigation">
+        <a href="#home" class="nav-link">Home</a>
+        <a href="#dosing" class="nav-link">Dosing Guide</a>
+        <a href="#verify" class="nav-link">Verify Cap</a>
+        <a href="#about" class="nav-link">About</a>
+      </nav>
+
+      <div class="header-actions">
+        <!-- Desktop theme toggle (compact icon strip) -->
+        <div class="theme-toggle-compact" role="group" aria-label="Appearance">
+          <button class="ttc-btn" data-theme-value="system" title="System">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+          </button>
+          <button class="ttc-btn" data-theme-value="light" title="Day">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          </button>
+          <button class="ttc-btn" data-theme-value="dark" title="Night">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          </button>
+        </div>
+
+        <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
+          <span class="ham-bar"></span>
+          <span class="ham-bar"></span>
+          <span class="ham-bar"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <!-- ═══════════════════════════════════════════
+       MOBILE MENU OVERLAY
+  ═══════════════════════════════════════════ -->
+  <div class="menu-backdrop" id="menuBackdrop" aria-hidden="true"></div>
+
+  <aside class="menu-panel" id="mobileMenu" role="dialog" aria-modal="true" aria-label="Navigation menu">
+    <div class="menu-panel-header">
+      <span class="menu-panel-title">Menu</span>
+      <button class="menu-close" id="menuClose" aria-label="Close menu">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+
+    <nav class="menu-nav" aria-label="Mobile navigation">
+      <a href="#home"   class="menu-link">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+        Home
+      </a>
+      <a href="#dosing" class="menu-link">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 3H5a2 2 0 0 0-2 2v4m6-6h10a2 2 0 0 1 2 2v4M9 3v18m0 0h10a2 2 0 0 0 2-2V9M9 21H5a2 2 0 0 1-2-2V9m0 0h18"/></svg>
+        Dosing Guide
+      </a>
+      <a href="#verify" class="menu-link">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        Verify Cap
+      </a>
+      <a href="#about"  class="menu-link">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        About
+      </a>
+    </nav>
+
+    <div class="menu-divider"></div>
+
+    <!-- Theme section inside hamburger -->
+    <div class="menu-theme-section">
+      <p class="menu-section-label">Appearance</p>
+      <div class="menu-theme-group" role="group" aria-label="Theme selection">
+        <button class="menu-theme-btn" data-theme-value="system">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+          <span>System</span>
+        </button>
+        <button class="menu-theme-btn" data-theme-value="light">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          <span>Day</span>
+        </button>
+        <button class="menu-theme-btn" data-theme-value="dark">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          <span>Night</span>
+        </button>
+      </div>
+    </div>
+  </aside>
+
+  <!-- ═══════════════════════════════════════════
+       MAIN CONTENT
+  ═══════════════════════════════════════════ -->
+  <main id="main-content">
+
+    <!-- HERO ──────────────────────────────────── -->
+    <section class="hero" id="home">
+      <div class="hero-bg-glow" aria-hidden="true"></div>
+      <div class="container hero-content">
+        <button class="cappy-btn" id="cappyBtn" aria-label="Meet Cappy">
+          <img
+            src="assets/images/cappy_circle.png"
+            alt="Cappy mascot"
+            class="cappy-img"
+            id="cappyImg"
+            onerror="this.onerror=null; this.src='assets/images/cappy_circle.svg'; this.style.padding='4px';"
+          >
+          <span class="cappy-pulse" aria-hidden="true"></span>
+        </button>
+        <h1 class="hero-title">Hello, I'm <em class="accent">Cappy!</em></h1>
+        <p class="hero-subtitle">Smart NFC medication tracking — verify, dose, and log with one tap</p>
+        <div class="hero-cta">
+          <a href="#dosing" class="btn btn-primary">Dosing Guide</a>
+          <a href="#verify" class="btn btn-outline">Verify Cap</a>
+        </div>
+        <div class="hero-badges">
+          <span class="badge">🔒 Ed25519 Verified</span>
+          <span class="badge">📡 NFC-Enabled</span>
+          <span class="badge">💊 Weight-Based Dosing</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- DOSING GUIDE ───────────────────────────── -->
+    <section class="section" id="dosing">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title">Weighing &amp; Dosing Guide</h2>
+          <p class="section-sub">Calculate safe, weight-based doses for common medications</p>
+        </div>
+
+        <!-- Calculator card -->
+        <div class="card card-featured" id="calculatorCard">
+          <div class="card-header">
+            <svg class="card-icon" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="8" y1="6" x2="16" y2="6"/><line x1="8" y1="10" x2="16" y2="10"/><line x1="8" y1="14" x2="12" y2="14"/></svg>
+            <h3 class="card-title">Dose Calculator</h3>
+          </div>
+          <div class="calc-form">
+            <div class="field-group">
+              <label class="field-label" for="weightInput">Patient Weight</label>
+              <div class="input-with-addon">
+                <input
+                  type="number"
+                  id="weightInput"
+                  class="field-input"
+                  placeholder="Enter weight"
+                  min="0.1"
+                  max="500"
+                  step="0.1"
+                  inputmode="decimal"
+                  aria-describedby="weightUnit"
+                >
+                <div class="unit-toggle" role="group" aria-label="Weight unit" id="weightUnit">
+                  <button class="unit-btn active" data-unit="kg">kg</button>
+                  <button class="unit-btn" data-unit="lbs">lbs</button>
+                </div>
+              </div>
+            </div>
+            <div class="field-group">
+              <label class="field-label" for="medSelect">Medication</label>
+              <select id="medSelect" class="field-select">
+                <option value="">Select a medication…</option>
+                <option value="ibuprofen"    data-dose="10" data-max="400" data-unit="mg" data-interval="every 6–8 hours">Ibuprofen (10 mg/kg)</option>
+                <option value="acetaminophen" data-dose="15" data-max="500" data-unit="mg" data-interval="every 4–6 hours">Acetaminophen / Paracetamol (15 mg/kg)</option>
+                <option value="amoxicillin"  data-dose="25" data-max="500" data-unit="mg" data-interval="every 8–12 hours">Amoxicillin (25 mg/kg)</option>
+                <option value="azithromycin" data-dose="10" data-max="250" data-unit="mg" data-interval="once daily">Azithromycin (10 mg/kg)</option>
+                <option value="prednisolone" data-dose="1"  data-max="40"  data-unit="mg" data-interval="once daily">Prednisolone (1 mg/kg)</option>
+              </select>
+            </div>
+            <button class="btn btn-primary btn-block" id="calcBtn">Calculate Dose</button>
+          </div>
+
+          <div class="result-box" id="resultBox" hidden aria-live="polite">
+            <div class="result-inner">
+              <div class="result-label">Recommended Dose</div>
+              <div class="result-dose" id="resultDose">—</div>
+              <div class="result-meta" id="resultMeta"></div>
+            </div>
+            <div class="result-disclaimer">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+              Always confirm doses with a licensed healthcare provider.
+            </div>
+          </div>
+        </div>
+
+        <!-- Reference guide grid -->
+        <div class="guide-grid">
+          <div class="card guide-card">
+            <div class="guide-card-icon" aria-hidden="true">⚖️</div>
+            <h3>Weighing Tips</h3>
+            <ul class="guide-list">
+              <li>Use a calibrated scale for each measurement</li>
+              <li>Weigh at the same time of day</li>
+              <li>Remove shoes and heavy clothing</li>
+              <li>Record weight in kilograms for precision</li>
+              <li>Reassess weight every 2–4 weeks for children</li>
+            </ul>
+          </div>
+          <div class="card guide-card">
+            <div class="guide-card-icon" aria-hidden="true">💊</div>
+            <h3>Dosing Intervals</h3>
+            <ul class="guide-list">
+              <li>Ibuprofen: every 6–8 hours (max 4 doses/day)</li>
+              <li>Acetaminophen: every 4–6 hours (max 5 doses/day)</li>
+              <li>Amoxicillin: every 8–12 hours</li>
+              <li>Azithromycin: once daily for 3–5 days</li>
+              <li>Never exceed the single-dose maximum</li>
+            </ul>
+          </div>
+          <div class="card guide-card">
+            <div class="guide-card-icon" aria-hidden="true">⚠️</div>
+            <h3>Safety Reminders</h3>
+            <ul class="guide-list">
+              <li>Always verify doses with your prescriber</li>
+              <li>Check for allergies and drug interactions</li>
+              <li>Use weight-based dosing for children &lt; 12 years</li>
+              <li>Log every dose with a timestamp in Cappy</li>
+              <li>Discard expired medications promptly</li>
+            </ul>
+          </div>
+          <div class="card guide-card">
+            <div class="guide-card-icon" aria-hidden="true">📏</div>
+            <h3>Unit Conversions</h3>
+            <ul class="guide-list">
+              <li>1 kg = 2.205 lbs</li>
+              <li>1 mg/mL = 1 g/L</li>
+              <li>1 teaspoon (tsp) = 5 mL</li>
+              <li>1 tablespoon (tbsp) = 15 mL</li>
+              <li>1 fluid ounce (fl oz) = 29.6 mL</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- VERIFY ──────────────────────────────────── -->
+    <section class="section section-alt" id="verify">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title">Verify Your Cap</h2>
+          <p class="section-sub">Hold your NFC-enabled device near the Cappy cap to confirm medication authenticity</p>
+        </div>
+
+        <div class="verify-card card">
+          <div class="verify-icon" aria-hidden="true">
+            <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z"/><line x1="3" y1="6" x2="21" y2="6"/><path d="M16 10a4 4 0 0 1-8 0"/></svg>
+          </div>
+          <p class="verify-instructions">
+            Place your phone's NFC reader on the top of the cap.<br>
+            Cappy will verify the cryptographic signature instantly.
+          </p>
+          <button class="btn btn-primary btn-lg" id="nfcBtn">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+            Scan Cap
+          </button>
+          <div class="verify-status" id="verifyStatus" role="status" aria-live="polite"></div>
+        </div>
+
+        <div class="verify-steps">
+          <div class="step">
+            <div class="step-num">1</div>
+            <p>Enable NFC in your device settings</p>
+          </div>
+          <div class="step-arrow" aria-hidden="true">→</div>
+          <div class="step">
+            <div class="step-num">2</div>
+            <p>Tap "Scan Cap" and hold near the cap</p>
+          </div>
+          <div class="step-arrow" aria-hidden="true">→</div>
+          <div class="step">
+            <div class="step-num">3</div>
+            <p>Receive instant verification result</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ABOUT ──────────────────────────────────── -->
+    <section class="section" id="about">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title">About Cappy</h2>
+          <p class="section-sub">Built on open cryptographic standards for trustworthy medication management</p>
+        </div>
+
+        <div class="about-grid">
+          <div class="card about-card">
+            <div class="about-icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+            </div>
+            <h3>Tamper-Evident</h3>
+            <p>Each cap carries an Ed25519 cryptographic signature. Any tampering is detected instantly on scan.</p>
+          </div>
+          <div class="card about-card">
+            <div class="about-icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
+            </div>
+            <h3>No App Needed</h3>
+            <p>Works with any NFC-capable smartphone browser. No installation, no account required to verify.</p>
+          </div>
+          <div class="card about-card">
+            <div class="about-icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+            </div>
+            <h3>Full Dose History</h3>
+            <p>Every scan is logged with a timestamp. Track doses, refills, and adherence over time.</p>
+          </div>
+          <div class="card about-card">
+            <div class="about-icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+            </div>
+            <h3>Multi-Patient</h3>
+            <p>Manage medications for the whole family. Each cap links to a specific patient profile.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ═══════════════════════════════════════════
+       FOOTER
+  ═══════════════════════════════════════════ -->
+  <footer class="footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <img src="assets/images/cappy_circle.png" alt="" class="footer-logo-img" aria-hidden="true" onerror="this.style.display='none'">
+        <span class="footer-wordmark">Cappy</span>
+      </div>
+      <p class="footer-copy">© 2024 Cappy. For informational use only. Always consult a healthcare provider.</p>
+      <nav class="footer-nav" aria-label="Footer navigation">
+        <a href="#">Privacy</a>
+        <a href="#">Terms</a>
+        <a href="#">Support</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/closedose-nfc/apps/web/styles.css
+++ b/closedose-nfc/apps/web/styles.css
@@ -1,0 +1,1164 @@
+/* ================================================================
+   CAPPY — DESIGN SYSTEM
+   Supports: Light (Day), Dark (Night), System (OS preference)
+   Theme is applied via [data-theme] on <html>; System mode uses
+   @media (prefers-color-scheme) with no data-theme attribute.
+   ================================================================ */
+
+/* ── Reset ────────────────────────────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
+img, svg { display: block; }
+button, input, select { font: inherit; }
+a { color: inherit; text-decoration: none; }
+ul { list-style: none; }
+
+/* ── CSS Custom Properties (Light defaults) ──────────────────── */
+:root {
+  /* Palette */
+  --clr-accent:        #0ea5e9;
+  --clr-accent-hover:  #0284c7;
+  --clr-accent-soft:   rgba(14, 165, 233, 0.12);
+  --clr-accent-rgb:    14, 165, 233;
+
+  --clr-success:       #10b981;
+  --clr-warning:       #f59e0b;
+  --clr-danger:        #ef4444;
+
+  /* Light surfaces */
+  --bg:                #f8fafc;
+  --bg-alt:            #f1f5f9;
+  --surface:           #ffffff;
+  --surface-2:         #f8fafc;
+  --surface-3:         #f1f5f9;
+  --border:            #e2e8f0;
+  --border-strong:     #cbd5e1;
+
+  /* Light text */
+  --text:              #0f172a;
+  --text-secondary:    #475569;
+  --text-muted:        #94a3b8;
+  --text-on-accent:    #ffffff;
+
+  /* Shadows */
+  --shadow-sm:         0 1px 2px rgba(0,0,0,0.06);
+  --shadow:            0 1px 3px rgba(0,0,0,0.08), 0 2px 6px rgba(0,0,0,0.06);
+  --shadow-md:         0 4px 12px rgba(0,0,0,0.08), 0 2px 4px rgba(0,0,0,0.06);
+  --shadow-lg:         0 10px 30px rgba(0,0,0,0.10), 0 4px 10px rgba(0,0,0,0.06);
+
+  /* Layout */
+  --header-h:          64px;
+  --radius-sm:         6px;
+  --radius:            12px;
+  --radius-lg:         20px;
+  --radius-full:       9999px;
+
+  /* Transitions */
+  --trans:             150ms ease;
+  --trans-med:         250ms ease;
+  --trans-slow:        350ms cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Typography scale */
+  --text-xs:    0.75rem;
+  --text-sm:    0.875rem;
+  --text-base:  1rem;
+  --text-lg:    1.125rem;
+  --text-xl:    1.25rem;
+  --text-2xl:   1.5rem;
+  --text-3xl:   1.875rem;
+  --text-4xl:   2.25rem;
+  --text-5xl:   3rem;
+
+  /* Header */
+  --header-bg:        rgba(248, 250, 252, 0.85);
+  --header-border:    rgba(226, 232, 240, 0.8);
+}
+
+/* ── Dark (Night) theme ──────────────────────────────────────── */
+/*
+   Background: deep charcoal slate (#111827) — replaces harsh dark blue.
+   Overscroll area (body background) matches so edges don't flash blue.
+   Card surfaces: fully opaque for maximum readability.
+*/
+[data-theme="dark"],
+@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) {
+  --clr-accent:        #38bdf8;
+  --clr-accent-hover:  #7dd3fc;
+  --clr-accent-soft:   rgba(56, 189, 248, 0.15);
+  --clr-accent-rgb:    56, 189, 248;
+
+  --bg:                #111827;   /* charcoal slate — not harsh blue */
+  --bg-alt:            #1a2233;
+  --surface:           #1e2d3d;   /* opaque card surface */
+  --surface-2:         #243447;
+  --surface-3:         #2a3d52;
+  --border:            #2d3f55;
+  --border-strong:     #3d5470;
+
+  --text:              #f0f6fc;
+  --text-secondary:    #b0c4d8;
+  --text-muted:        #7a95b0;
+  --text-on-accent:    #ffffff;
+
+  --shadow-sm:         0 1px 2px rgba(0,0,0,0.4);
+  --shadow:            0 1px 3px rgba(0,0,0,0.4), 0 2px 6px rgba(0,0,0,0.3);
+  --shadow-md:         0 4px 12px rgba(0,0,0,0.45), 0 2px 4px rgba(0,0,0,0.3);
+  --shadow-lg:         0 10px 30px rgba(0,0,0,0.55), 0 4px 10px rgba(0,0,0,0.35);
+
+  --header-bg:         rgba(17, 24, 39, 0.9);
+  --header-border:     rgba(45, 63, 85, 0.9);
+}}
+
+/* explicit dark attribute (for when JS sets it directly) */
+[data-theme="dark"] {
+  --clr-accent:        #38bdf8;
+  --clr-accent-hover:  #7dd3fc;
+  --clr-accent-soft:   rgba(56, 189, 248, 0.15);
+  --clr-accent-rgb:    56, 189, 248;
+
+  --bg:                #111827;
+  --bg-alt:            #1a2233;
+  --surface:           #1e2d3d;
+  --surface-2:         #243447;
+  --surface-3:         #2a3d52;
+  --border:            #2d3f55;
+  --border-strong:     #3d5470;
+
+  --text:              #f0f6fc;
+  --text-secondary:    #b0c4d8;
+  --text-muted:        #7a95b0;
+  --text-on-accent:    #ffffff;
+
+  --shadow-sm:         0 1px 2px rgba(0,0,0,0.4);
+  --shadow:            0 1px 3px rgba(0,0,0,0.4), 0 2px 6px rgba(0,0,0,0.3);
+  --shadow-md:         0 4px 12px rgba(0,0,0,0.45), 0 2px 4px rgba(0,0,0,0.3);
+  --shadow-lg:         0 10px 30px rgba(0,0,0,0.55), 0 4px 10px rgba(0,0,0,0.35);
+
+  --header-bg:         rgba(17, 24, 39, 0.9);
+  --header-border:     rgba(45, 63, 85, 0.9);
+}
+
+/* ── Base ────────────────────────────────────────────────────── */
+html {
+  background-color: var(--bg);  /* prevents white flash on overscroll */
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text);
+  background-color: var(--bg);
+  transition: background-color var(--trans-med), color var(--trans-med);
+  min-height: 100dvh;
+  overflow-x: hidden;
+}
+
+/* ── Layout Utilities ────────────────────────────────────────── */
+.container {
+  width: 100%;
+  max-width: 1100px;
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 5vw, 2rem);
+}
+
+/* ── Typography ──────────────────────────────────────────────── */
+.accent { font-style: normal; color: var(--clr-accent); }
+
+/* ================================================================
+   HEADER
+   ================================================================ */
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  height: var(--header-h);
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--header-border);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: background var(--trans-med), border-color var(--trans-med);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  gap: 1.5rem;
+}
+
+/* Logo */
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.logo-img {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+}
+
+.logo-wordmark {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+/* Desktop nav */
+.nav-desktop {
+  display: none;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+@media (min-width: 768px) {
+  .nav-desktop { display: flex; }
+}
+
+.nav-link {
+  padding: 0.5rem 0.875rem;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: color var(--trans), background-color var(--trans);
+}
+
+.nav-link:hover {
+  color: var(--text);
+  background-color: var(--surface-3);
+}
+
+/* Header actions (theme strip + hamburger) */
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+@media (min-width: 768px) {
+  .header-actions { margin-left: 0; }
+}
+
+/* Compact theme toggle (desktop) */
+.theme-toggle-compact {
+  display: none;
+  align-items: center;
+  background: var(--surface-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 2px;
+  gap: 1px;
+}
+
+@media (min-width: 768px) {
+  .theme-toggle-compact { display: flex; }
+}
+
+.ttc-btn {
+  width: 30px;
+  height: 30px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--trans), color var(--trans);
+}
+
+.ttc-btn:hover {
+  background: var(--surface);
+  color: var(--text);
+}
+
+.ttc-btn.active {
+  background: var(--clr-accent);
+  color: var(--text-on-accent);
+}
+
+/* Hamburger */
+.hamburger {
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  padding: 8px;
+  color: var(--text);
+  transition: background-color var(--trans);
+}
+
+.hamburger:hover { background: var(--surface-3); }
+
+.ham-bar {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background-color: currentColor;
+  border-radius: 2px;
+  transition: transform var(--trans-med), opacity var(--trans-med), width var(--trans-med);
+  transform-origin: center;
+}
+
+/* Hamburger → X animation */
+.hamburger[aria-expanded="true"] .ham-bar:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.hamburger[aria-expanded="true"] .ham-bar:nth-child(2) { opacity: 0; transform: scaleX(0); }
+.hamburger[aria-expanded="true"] .ham-bar:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+/* ================================================================
+   MOBILE MENU
+   ================================================================ */
+.menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--trans-slow), visibility var(--trans-slow);
+}
+
+.menu-backdrop.open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.menu-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 201;
+  width: min(320px, 85vw);
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem;
+  gap: 0;
+  transform: translateX(100%);
+  transition: transform var(--trans-slow);
+  overflow-y: auto;
+}
+
+.menu-panel.open {
+  transform: translateX(0);
+}
+
+.menu-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.menu-panel-title {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text);
+}
+
+.menu-close {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border);
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--trans), color var(--trans);
+}
+
+.menu-close:hover { background: var(--surface-3); color: var(--text); }
+
+/* Menu nav links */
+.menu-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-block: 0.5rem;
+}
+
+.menu-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0.875rem;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: background-color var(--trans), color var(--trans);
+}
+
+.menu-link:hover, .menu-link:focus-visible {
+  background: var(--surface-3);
+  color: var(--text);
+}
+
+.menu-link svg { flex-shrink: 0; opacity: 0.7; }
+
+/* Divider */
+.menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin-block: 0.75rem;
+}
+
+/* Theme section inside menu */
+.menu-theme-section { padding-top: 0.25rem; }
+
+.menu-section-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 0.25rem 0.25rem 0.75rem;
+}
+
+.menu-theme-group {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+
+.menu-theme-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.875rem 0.5rem;
+  border: 1.5px solid var(--border);
+  background: var(--surface-2);
+  border-radius: var(--radius);
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  transition: background-color var(--trans), border-color var(--trans), color var(--trans), box-shadow var(--trans);
+}
+
+.menu-theme-btn:hover {
+  background: var(--surface-3);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.menu-theme-btn.active {
+  background: var(--clr-accent-soft);
+  border-color: var(--clr-accent);
+  color: var(--clr-accent);
+  box-shadow: 0 0 0 3px var(--clr-accent-soft);
+}
+
+/* ================================================================
+   CARDS — Base
+   ================================================================ */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  transition: background-color var(--trans-med), border-color var(--trans-med), box-shadow var(--trans-med);
+}
+
+.card:hover { box-shadow: var(--shadow-md); }
+
+.card-featured {
+  border-color: rgba(var(--clr-accent-rgb), 0.3);
+  box-shadow: var(--shadow-md), 0 0 0 1px rgba(var(--clr-accent-rgb), 0.1);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.card-icon {
+  color: var(--clr-accent);
+  flex-shrink: 0;
+}
+
+.card-title {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--text);
+}
+
+/* ================================================================
+   BUTTONS
+   ================================================================ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: background-color var(--trans), color var(--trans), border-color var(--trans), transform var(--trans), box-shadow var(--trans);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.btn:active { transform: scale(0.97); }
+
+.btn-primary {
+  background: var(--clr-accent);
+  color: var(--text-on-accent);
+  border-color: var(--clr-accent);
+}
+
+.btn-primary:hover {
+  background: var(--clr-accent-hover);
+  border-color: var(--clr-accent-hover);
+  box-shadow: 0 4px 14px rgba(var(--clr-accent-rgb), 0.4);
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--clr-accent);
+  border-color: var(--clr-accent);
+}
+
+.btn-outline:hover {
+  background: var(--clr-accent-soft);
+}
+
+.btn-block { width: 100%; }
+
+.btn-lg {
+  padding: 0.875rem 2rem;
+  font-size: var(--text-base);
+  border-radius: var(--radius);
+}
+
+/* ================================================================
+   HERO
+   ================================================================ */
+.hero {
+  position: relative;
+  min-height: calc(100dvh - var(--header-h));
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  padding-block: clamp(3rem, 10vh, 6rem);
+}
+
+/* subtle gradient glow — not harsh */
+.hero-bg-glow {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 0%, rgba(var(--clr-accent-rgb), 0.08) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.hero-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+/* Cappy button */
+.cappy-btn {
+  position: relative;
+  width: clamp(110px, 22vw, 160px);
+  height: clamp(110px, 22vw, 160px);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.cappy-img {
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+  position: relative;
+  z-index: 1;
+  box-shadow: var(--shadow-lg), 0 0 0 4px var(--surface), 0 0 0 6px rgba(var(--clr-accent-rgb), 0.3);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.cappy-btn:hover .cappy-img { transform: scale(1.05); }
+.cappy-btn:active .cappy-img { transform: scale(0.97); }
+
+/* Animated pulse ring */
+.cappy-pulse {
+  position: absolute;
+  inset: -6px;
+  border-radius: var(--radius-full);
+  border: 2px solid rgba(var(--clr-accent-rgb), 0.35);
+  animation: pulse-ring 2.5s ease-out infinite;
+}
+
+@keyframes pulse-ring {
+  0%   { transform: scale(0.9); opacity: 0.8; }
+  60%  { transform: scale(1.15); opacity: 0; }
+  100% { transform: scale(1.15); opacity: 0; }
+}
+
+.hero-title {
+  font-size: clamp(var(--text-3xl), 6vw, var(--text-5xl));
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  color: var(--text);
+}
+
+.hero-subtitle {
+  font-size: clamp(var(--text-base), 2.5vw, var(--text-xl));
+  color: var(--text-secondary);
+  max-width: 520px;
+  line-height: 1.5;
+}
+
+.hero-cta {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hero-cta .btn { padding: 0.75rem 1.75rem; font-size: var(--text-base); }
+
+.hero-badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.875rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+/* ================================================================
+   SECTIONS
+   ================================================================ */
+.section {
+  padding-block: clamp(3rem, 8vw, 5rem);
+}
+
+.section-alt {
+  background: var(--bg-alt);
+  transition: background-color var(--trans-med);
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: clamp(2rem, 5vw, 3rem);
+}
+
+.section-title {
+  font-size: clamp(var(--text-2xl), 4vw, var(--text-4xl));
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+  color: var(--text);
+  margin-bottom: 0.75rem;
+}
+
+.section-sub {
+  font-size: var(--text-lg);
+  color: var(--text-secondary);
+  max-width: 540px;
+  margin-inline: auto;
+  line-height: 1.5;
+}
+
+/* ================================================================
+   DOSE CALCULATOR
+   ================================================================ */
+#calculatorCard { margin-bottom: 2.5rem; }
+
+.calc-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.field-label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.input-with-addon {
+  display: flex;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  transition: border-color var(--trans);
+  background: var(--surface-2);
+}
+
+.input-with-addon:focus-within {
+  border-color: var(--clr-accent);
+  box-shadow: 0 0 0 3px var(--clr-accent-soft);
+}
+
+.field-input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: var(--text-base);
+  outline: none;
+  min-width: 0;
+}
+
+.field-input::placeholder { color: var(--text-muted); }
+
+.unit-toggle {
+  display: flex;
+  border-left: 1.5px solid var(--border);
+  background: var(--surface-3);
+}
+
+.unit-btn {
+  padding: 0 0.875rem;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color var(--trans), color var(--trans);
+}
+
+.unit-btn:hover { background: var(--surface); color: var(--text); }
+
+.unit-btn.active {
+  background: var(--clr-accent);
+  color: var(--text-on-accent);
+}
+
+.field-select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: var(--text-base);
+  outline: none;
+  cursor: pointer;
+  transition: border-color var(--trans);
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2.5' stroke-linecap='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  padding-right: 2.5rem;
+}
+
+.field-select:focus {
+  border-color: var(--clr-accent);
+  box-shadow: 0 0 0 3px var(--clr-accent-soft);
+}
+
+/* Result box */
+.result-box {
+  margin-top: 0.5rem;
+  border: 1.5px solid rgba(var(--clr-accent-rgb), 0.4);
+  border-radius: var(--radius);
+  background: var(--clr-accent-soft);
+  overflow: hidden;
+  animation: slide-in 0.25s ease;
+}
+
+@keyframes slide-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.result-inner {
+  padding: 1.25rem;
+}
+
+.result-label {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--clr-accent);
+  margin-bottom: 0.4rem;
+}
+
+.result-dose {
+  font-size: var(--text-3xl);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.result-meta {
+  margin-top: 0.35rem;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.result-disclaimer {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.25rem;
+  background: rgba(var(--clr-accent-rgb), 0.06);
+  border-top: 1px solid rgba(var(--clr-accent-rgb), 0.2);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+/* ================================================================
+   DOSING GUIDE GRID
+   ================================================================ */
+.guide-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 240px), 1fr));
+  gap: 1.25rem;
+}
+
+.guide-card {
+  /* Solid background — no transparency in dark mode */
+  background: var(--surface);
+}
+
+.guide-card-icon {
+  font-size: 2rem;
+  margin-bottom: 0.75rem;
+  line-height: 1;
+}
+
+.guide-card h3 {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.875rem;
+}
+
+.guide-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.guide-list li {
+  position: relative;
+  padding-left: 1.1rem;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.guide-list li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: var(--clr-accent);
+  font-weight: 700;
+}
+
+/* ================================================================
+   VERIFY SECTION
+   ================================================================ */
+.verify-card {
+  max-width: 480px;
+  margin-inline: auto;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 2.5rem 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.verify-icon {
+  color: var(--clr-accent);
+  opacity: 0.85;
+}
+
+.verify-instructions {
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.verify-status {
+  min-height: 2rem;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 1rem;
+  transition: all var(--trans-med);
+}
+
+.verify-status.success {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--clr-success);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.verify-status.error {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--clr-danger);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+/* Steps row */
+.verify-steps {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  max-width: 600px;
+  margin-inline: auto;
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: center;
+  max-width: 140px;
+}
+
+.step-num {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  background: var(--clr-accent);
+  color: var(--text-on-accent);
+  font-weight: 700;
+  font-size: var(--text-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.step p {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.step-arrow {
+  font-size: var(--text-xl);
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+@media (max-width: 480px) {
+  .step-arrow { display: none; }
+  .verify-steps { flex-direction: column; }
+}
+
+/* ================================================================
+   ABOUT GRID
+   ================================================================ */
+.about-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
+  gap: 1.25rem;
+}
+
+.about-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.about-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius);
+  background: var(--clr-accent-soft);
+  color: var(--clr-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.about-card h3 {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text);
+}
+
+.about-card p {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ================================================================
+   FOOTER
+   ================================================================ */
+.footer {
+  background: var(--bg-alt);
+  border-top: 1px solid var(--border);
+  padding-block: 2rem;
+  transition: background-color var(--trans-med), border-color var(--trans-med);
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.footer-logo-img {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+}
+
+.footer-wordmark {
+  font-weight: 700;
+  font-size: var(--text-base);
+  color: var(--text);
+}
+
+.footer-copy {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.footer-nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.footer-nav a {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  transition: color var(--trans);
+}
+
+.footer-nav a:hover { color: var(--text); }
+
+/* ================================================================
+   FOCUS STYLES (accessibility)
+   ================================================================ */
+:focus-visible {
+  outline: 2px solid var(--clr-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ================================================================
+   RESPONSIVE REFINEMENTS
+   ================================================================ */
+@media (min-width: 640px) {
+  .calc-form {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .calc-form .btn-block {
+    grid-column: 1 / -1;
+  }
+
+  .result-box { grid-column: 1 / -1; }
+}
+
+@media (min-width: 768px) {
+  .guide-grid { grid-template-columns: repeat(2, 1fr); }
+  .about-grid { grid-template-columns: repeat(2, 1fr); }
+
+  .footer-inner { flex-wrap: nowrap; }
+}
+
+@media (min-width: 1024px) {
+  .guide-grid { grid-template-columns: repeat(4, 1fr); }
+  .about-grid { grid-template-columns: repeat(4, 1fr); }
+}
+
+/* ================================================================
+   PRINT
+   ================================================================ */
+@media print {
+  .header, .hamburger, .menu-backdrop, .menu-panel, .hero-cta, .footer { display: none !important; }
+  .hero { min-height: auto; padding-block: 2rem; }
+  .card { box-shadow: none; border: 1px solid #ddd; }
+}


### PR DESCRIPTION
## Summary

- **Dark background overhaul** — replaces the harsh dark-blue page background with deep charcoal slate (`#111827`); overscroll edges no longer flash an unpleasant colour on mobile bounce/pull
- **Opaque dark-mode card surfaces** — dosing & weighing guide boxes use solid `#1e2d3d` surfaces (no transparency) for clear readability in Night mode
- **System / Day / Night theme toggle** — preference stored in `localStorage` and applied to `<html data-theme>` *before* first paint to eliminate flash; System mode auto-tracks OS `prefers-color-scheme`; toggle is present in both the desktop header strip and the hamburger menu
- **Hamburger menu panel** — slide-in side drawer with focus-trap, backdrop dismiss, Escape key close, and smooth `×` animation
- **`cappy_circle.png` image path fixed** — all references point to `assets/images/cappy_circle.png`; an SVG fallback (`cappy_circle.svg`) auto-loads when the PNG is absent so the Cappy button always renders
- **Weighing & Dosing Guide** — interactive weight-based dose calculator (kg/lbs toggle, per-medication max caps, accessible live result) plus four reference cards
- **Mobile-first responsive layout** — fluid typography, CSS `clamp()`, grid auto-fill, safe-area insets, sticky header with scroll shadow

## Test plan

- [ ] Open site in a browser; confirm page background is dark charcoal (not blue) in Night mode
- [ ] Scroll to edge/overscroll on mobile — confirm no blue flash at edges
- [ ] Open hamburger menu → confirm System / Day / Night buttons appear and switch themes
- [ ] Toggle theme, close tab, reopen — confirm preference persists (localStorage)
- [ ] Select System → change OS theme → confirm site follows without interaction
- [ ] Enter a weight + medication → tap Calculate Dose → verify result appears
- [ ] Tap Cappy! button → confirm mascot image loads (or SVG fallback) and toast appears
- [ ] Resize to 375px mobile width → confirm layout stacks correctly, no overflow

## Aesthetic recommendations (follow-up)

The following improvements are noted for a subsequent PR:
1. **Scroll-to-top FAB** on mobile once the user scrolls past the hero
2. **Skeleton loading states** for calculator result box
3. **Bottom nav bar** on mobile (Home / Dosing / Verify / About) as an alternative to hamburger
4. **Micro-animations** on card entrance (Intersection Observer fade-up)
5. **Dose history log** — a collapsible `<details>` section below the calculator showing previous calculations in the session

https://claude.ai/code/session_01HsyShpXXMdNjoVGyaj63Z5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsyShpXXMdNjoVGyaj63Z5)_