### PR TITLE
Add SwiftUI iOS scaffold: app entry, design tokens, UI components, logging, and home dashboard

### DIFF
--- a/cappy-buildplan/ios/Cappy/App/AppEnvironment.swift
+++ b/cappy-buildplan/ios/Cappy/App/AppEnvironment.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct AppEnvironment {
+    let apiBaseURL: URL
+    let logger: CappyLogger
+
+    static let preview = AppEnvironment(
+        apiBaseURL: URL(string: "https://staging.cappy.app")!,
+        logger: CappyLogger(subsystem: "app.cappy.ios", category: "preview")
+    )
+}

--- a/cappy-buildplan/ios/Cappy/App/CappyApp.swift
+++ b/cappy-buildplan/ios/Cappy/App/CappyApp.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@main
+struct CappyApp: App {
+    private let environment = AppEnvironment.preview
+
+    var body: some Scene {
+        WindowGroup {
+            RootView(environment: environment)
+        }
+    }
+}
+
+struct RootView: View {
+    let environment: AppEnvironment
+
+    var body: some View {
+        HomeDashboardView(environment: environment)
+            .preferredColorScheme(nil)
+    }
+}

--- a/cappy-buildplan/ios/Cappy/Core/Logging/CappyLogger.swift
+++ b/cappy-buildplan/ios/Cappy/Core/Logging/CappyLogger.swift
@@ -1,0 +1,45 @@
+import Foundation
+import OSLog
+
+struct CappyLogger {
+    private let logger: Logger
+
+    init(subsystem: String, category: String) {
+        self.logger = Logger(subsystem: subsystem, category: category)
+    }
+
+    func info(_ event: SafeLogEvent) {
+        logger.info("\(event.name, privacy: .public) \(event.safeMetadataDescription, privacy: .public)")
+    }
+
+    func error(_ event: SafeLogEvent) {
+        logger.error("\(event.name, privacy: .public) \(event.safeMetadataDescription, privacy: .public)")
+    }
+}
+
+struct SafeLogEvent {
+    let name: String
+    let metadata: [String: String]
+
+    init(name: String, metadata: [String: String] = [:]) {
+        self.name = name
+        self.metadata = metadata.filter { Self.allowedMetadataKeys.contains($0.key) }
+    }
+
+    var safeMetadataDescription: String {
+        guard metadata.isEmpty == false else { return "{}" }
+        return metadata
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: " ")
+    }
+
+    private static let allowedMetadataKeys: Set<String> = [
+        "duration_ms",
+        "environment",
+        "event_id",
+        "request_id",
+        "screen",
+        "status"
+    ]
+}

--- a/cappy-buildplan/ios/Cappy/Design/Components/CappyButton.swift
+++ b/cappy-buildplan/ios/Cappy/Design/Components/CappyButton.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct CappyButton: View {
+    enum Style {
+        case primary
+        case secondary
+        case destructive
+    }
+
+    let title: String
+    let style: Style
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(CappyTypography.callout.weight(.semibold))
+                .frame(maxWidth: .infinity, minHeight: CappyTouchTarget.minimum)
+                .foregroundStyle(foregroundColor)
+                .padding(.horizontal, CappySpacing.md)
+                .background(backgroundColor)
+                .clipShape(RoundedRectangle(cornerRadius: CappyRadius.md, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+
+    private var backgroundColor: Color {
+        switch style {
+        case .primary: CappyColor.brandPrimary
+        case .secondary: CappyColor.backgroundSecondary
+        case .destructive: CappyColor.statusDangerBackground
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch style {
+        case .primary: CappyColor.textInverse
+        case .secondary: CappyColor.textPrimary
+        case .destructive: CappyColor.statusDangerForeground
+        }
+    }
+}

--- a/cappy-buildplan/ios/Cappy/Design/Components/CappyCard.swift
+++ b/cappy-buildplan/ios/Cappy/Design/Components/CappyCard.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct CappyCard<Content: View>: View {
+    private let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(CappySpacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(CappyColor.backgroundElevated)
+            .clipShape(RoundedRectangle(cornerRadius: CappyRadius.lg, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: CappyRadius.lg, style: .continuous)
+                    .stroke(CappyColor.divider, lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.08), radius: 16, x: 0, y: 8)
+    }
+}

--- a/cappy-buildplan/ios/Cappy/Design/Components/ChildAvatar.swift
+++ b/cappy-buildplan/ios/Cappy/Design/Components/ChildAvatar.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct ChildAvatar: View {
+    let initials: String
+    let color: Color
+
+    var body: some View {
+        Text(initials.prefix(2).uppercased())
+            .font(CappyTypography.caption.weight(.semibold))
+            .foregroundStyle(.white)
+            .frame(width: CappyTouchTarget.minimum, height: CappyTouchTarget.minimum)
+            .background(color)
+            .clipShape(Circle())
+            .accessibilityHidden(true)
+    }
+}

--- a/cappy-buildplan/ios/Cappy/Design/Components/DoseStatusPill.swift
+++ b/cappy-buildplan/ios/Cappy/Design/Components/DoseStatusPill.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct DoseStatusPill: View {
+    enum Status {
+        case safe
+        case dueSoon
+        case tooEarly
+        case pendingSync
+    }
+
+    let status: Status
+
+    var body: some View {
+        Text(label)
+            .font(CappyTypography.caption.weight(.semibold))
+            .padding(.horizontal, CappySpacing.sm)
+            .padding(.vertical, CappySpacing.xs)
+            .foregroundStyle(foregroundColor)
+            .background(backgroundColor)
+            .clipShape(Capsule())
+            .accessibilityLabel("Dose status: \(label)")
+    }
+
+    private var label: String {
+        switch status {
+        case .safe: "Ready to log"
+        case .dueSoon: "Check timing"
+        case .tooEarly: "Too soon"
+        case .pendingSync: "Pending sync"
+        }
+    }
+
+    private var foregroundColor: Color {
+        switch status {
+        case .safe: CappyColor.statusSafeForeground
+        case .dueSoon: CappyColor.statusWarningForeground
+        case .tooEarly: CappyColor.statusDangerForeground
+        case .pendingSync: CappyColor.statusInfoForeground
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch status {
+        case .safe: CappyColor.statusSafeBackground
+        case .dueSoon: CappyColor.statusWarningBackground
+        case .tooEarly: CappyColor.statusDangerBackground
+        case .pendingSync: CappyColor.statusInfoBackground
+        }
+    }
+}

--- a/cappy-buildplan/ios/Cappy/Design/Tokens.swift
+++ b/cappy-buildplan/ios/Cappy/Design/Tokens.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import UIKit
+
+enum CappyColor {
+    static let backgroundPrimary = Color(light: 0xFFFFFF, dark: 0x0B0F14)
+    static let backgroundSecondary = Color(light: 0xF5F7FA, dark: 0x161B22)
+    static let backgroundElevated = Color(light: 0xFFFFFF, dark: 0x1C232C)
+
+    static let textPrimary = Color(light: 0x0B0F14, dark: 0xF5F7FA)
+    static let textSecondary = Color(light: 0x4A5560, dark: 0xA8B0BB)
+    static let textTertiary = Color(light: 0x7B8694, dark: 0x7B8694)
+    static let textInverse = Color(light: 0xFFFFFF, dark: 0x0B0F14)
+
+    static let brandPrimary = Color(hex: 0x1F6FEB)
+    static let brandSecondary = Color(hex: 0x6E40C9)
+
+    static let statusSafeForeground = Color(hex: 0x0B5E2A)
+    static let statusSafeBackground = Color(hex: 0xE6F4EA)
+    static let statusWarningForeground = Color(hex: 0x7A4F00)
+    static let statusWarningBackground = Color(hex: 0xFFF4D6)
+    static let statusDangerForeground = Color(hex: 0x9B1C1C)
+    static let statusDangerBackground = Color(hex: 0xFDE7E7)
+    static let statusInfoForeground = Color(hex: 0x1F4F9B)
+    static let statusInfoBackground = Color(hex: 0xE6EEF9)
+
+    static let divider = Color(light: 0xE1E4E8, dark: 0x2D333B)
+}
+
+enum CappySpacing {
+    static let xs: CGFloat = 4
+    static let sm: CGFloat = 8
+    static let md: CGFloat = 16
+    static let lg: CGFloat = 24
+    static let xl: CGFloat = 32
+    static let xxl: CGFloat = 48
+}
+
+enum CappyRadius {
+    static let sm: CGFloat = 6
+    static let md: CGFloat = 12
+    static let lg: CGFloat = 20
+    static let full: CGFloat = 9999
+}
+
+enum CappyTypography {
+    static let display = Font.system(size: 28, weight: .semibold)
+    static let title = Font.system(size: 22, weight: .semibold)
+    static let subtitle = Font.system(size: 17, weight: .medium)
+    static let body = Font.system(size: 17, weight: .regular)
+    static let callout = Font.system(size: 16, weight: .regular)
+    static let caption = Font.system(size: 13, weight: .regular)
+}
+
+enum CappyMotion {
+    static let fast = 0.150
+    static let medium = 0.250
+    static let slow = 0.400
+}
+
+enum CappyTouchTarget {
+    static let minimum: CGFloat = 44
+}
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255.0,
+            green: Double((hex >> 8) & 0xFF) / 255.0,
+            blue: Double(hex & 0xFF) / 255.0
+        )
+    }
+
+    init(light: UInt, dark: UInt) {
+        self.init(UIColor { traitCollection in
+            let value = traitCollection.userInterfaceStyle == .dark ? dark : light
+            return UIColor(
+                red: CGFloat((value >> 16) & 0xFF) / 255.0,
+                green: CGFloat((value >> 8) & 0xFF) / 255.0,
+                blue: CGFloat(value & 0xFF) / 255.0,
+                alpha: 1
+            )
+        })
+    }
+}

--- a/cappy-buildplan/ios/Cappy/Features/Doses/HomeDashboardView.swift
+++ b/cappy-buildplan/ios/Cappy/Features/Doses/HomeDashboardView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct HomeDashboardView: View {
+    let environment: AppEnvironment
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: CappySpacing.md) {
+                    header
+                    nfcCard
+                    lastDoseCard
+                    timelineCard
+                }
+                .padding(CappySpacing.md)
+            }
+            .background(CappyColor.backgroundPrimary)
+            .navigationTitle("Cappy")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Settings") {}
+                        .font(CappyTypography.caption)
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: CappySpacing.sm) {
+            Text("Medication coordination")
+                .font(CappyTypography.display)
+                .foregroundStyle(CappyColor.textPrimary)
+            Text("Tap a bottle tag to open the right shared dose log.")
+                .font(CappyTypography.body)
+                .foregroundStyle(CappyColor.textSecondary)
+        }
+    }
+
+    private var nfcCard: some View {
+        CappyCard {
+            VStack(alignment: .leading, spacing: CappySpacing.sm) {
+                DoseStatusPill(status: .pendingSync)
+                Text("NFC quick access")
+                    .font(CappyTypography.title)
+                    .foregroundStyle(CappyColor.textPrimary)
+                Text("Use Core NFC to read a tag UID only. Medication and child context resolves through the authenticated API.")
+                    .font(CappyTypography.callout)
+                    .foregroundStyle(CappyColor.textSecondary)
+                CappyButton(title: "Scan tag", style: .primary) {
+                    environment.logger.info(SafeLogEvent(name: "nfc_scan_requested", metadata: ["screen": "home"]))
+                }
+            }
+        }
+    }
+
+    private var lastDoseCard: some View {
+        CappyCard {
+            HStack(alignment: .top, spacing: CappySpacing.md) {
+                ChildAvatar(initials: "CP", color: CappyColor.brandSecondary)
+                VStack(alignment: .leading, spacing: CappySpacing.xs) {
+                    Text("Last dose")
+                        .font(CappyTypography.subtitle)
+                        .foregroundStyle(CappyColor.textPrimary)
+                    Text("No sample child data is bundled. Real child and dose details load only after authenticated setup.")
+                        .font(CappyTypography.caption)
+                        .foregroundStyle(CappyColor.textSecondary)
+                }
+            }
+        }
+    }
+
+    private var timelineCard: some View {
+        CappyCard {
+            VStack(alignment: .leading, spacing: CappySpacing.sm) {
+                Text("Shared timeline")
+                    .font(CappyTypography.title)
+                    .foregroundStyle(CappyColor.textPrimary)
+                Text("Upcoming work will merge local pending events with server-confirmed dose events and realtime updates.")
+                    .font(CappyTypography.callout)
+                    .foregroundStyle(CappyColor.textSecondary)
+            }
+        }
+    }
+}

--- a/cappy-buildplan/ios/Cappy/Resources/Assets.xcassets/Contents.json
+++ b/cappy-buildplan/ios/Cappy/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/cappy-buildplan/ios/Cappy/Resources/Localizable.strings
+++ b/cappy-buildplan/ios/Cappy/Resources/Localizable.strings
@@ -1,0 +1,1 @@
+"app.name" = "Cappy";

--- a/cappy-buildplan/ios/README.md
+++ b/cappy-buildplan/ios/README.md
@@ -1,17 +1,42 @@
-# iOS App
+# Cappy iOS App
 
-This directory will be populated in Milestone 2 (days 22-49). The
-Mobile Engineer agent will create the Xcode project here.
+Native iOS is the alpha mobile target for Cappy. ADR-0004 rejects React Native and Flutter for the alpha because the product depends on reliable NFC behavior and a sub-second tap-to-screen path.
 
-See `/agents/mobile-engineer.md` for the iOS stack and conventions.
-See `/project/PLAN.md` for Milestone 2 goals and exit criteria.
+## Current scaffold
 
-The first iOS ticket should:
-1. Initialize the Xcode project at `/ios/Cappy.xcodeproj`
-2. Create the directory structure described in
-   `/agents/mobile-engineer.md`
-3. Wire the OpenAPI client generator to produce a Swift client from
-   `/contracts/openapi/cappy.yaml`
-4. Confirm the project builds clean with `xcodebuild -scheme Cappy build`
+This directory now contains the first native SwiftUI source scaffold for the Cappy app:
 
-Until then, this directory remains empty.
+```text
+/ios/
+  /Cappy/
+    /App/                 App entry point and dependency root
+    /Features/            Auth, Family, Children, NFC, Doses, Settings
+    /Core/                Networking, Persistence, Crypto, Realtime, Logging
+    /Design/              Tokens and reusable SwiftUI components
+    /Resources/           Assets and localizable resources
+  /CappyTests/
+  /CappyUITests/
+```
+
+An Xcode project still needs to be generated on macOS. The next mobile ticket should create `Cappy.xcodeproj`, attach these source files to the app target, set the minimum deployment target to iOS 16, and run `xcodebuild -scheme Cappy build`.
+
+## Design system source of truth
+
+`../design/tokens.json` is the machine-readable source of truth for app colors, spacing, typography, radii, motion, and touch target minimums. `Cappy/Design/Tokens.swift` is the native SwiftUI bridge and should be updated whenever the token JSON changes.
+
+The visual references in `../../Cappy Design System_6.29.26/` are useful for component behavior and tone, but the alpha app should implement Cappy coordination screens rather than CloseDose dose-calculation screens.
+
+## Safety notes
+
+- Do not log child names, caregiver names, medication details, dose details, email addresses, or other PHI.
+- NFC tags carry only a UID. Medication and child context must come from the authenticated API.
+- Dose logging must eventually use a local pending state and an idempotency key before syncing to the server.
+- Cappy coordinates a shared record; it must not present itself as clinical guidance.
+
+## Immediate next steps
+
+1. Generate `Cappy.xcodeproj` on macOS and attach the scaffolded sources.
+2. Add the Core NFC entitlement and spike real NTAG215 UID reading on device.
+3. Generate the Swift API client from `contracts/openapi/cappy.yaml` once the contract is complete.
+4. Add Core Data models for pending dose events and cached family context.
+5. Add SwiftUI previews and XCTest coverage for design components.

--- a/cappy-buildplan/project/retros/2026-06-30-TICKET-IOS-SCAFFOLD.md
+++ b/cappy-buildplan/project/retros/2026-06-30-TICKET-IOS-SCAFFOLD.md
@@ -1,0 +1,40 @@
+# Retrospective: TICKET-IOS-SCAFFOLD
+
+**Date:** 2026-06-30
+**Agent role:** Mobile Engineer
+**Ticket:** Founder-directed iOS app scaffold kickoff
+**Outcome:** Done with follow-ups
+
+## What went well
+
+- The build plan and mobile engineer prompt clearly established native iOS as the alpha direction.
+- The design tokens file provided enough structure to create an initial SwiftUI token bridge.
+- The design system included enough component references to seed the first Cappy-native card, button, avatar, and status pill components.
+
+## What was harder than expected
+
+- The repository does not currently include an Xcode project generator or a macOS/Xcode environment, so the scaffold could not be compiled with `xcodebuild` here.
+- The design system contains CloseDose dose-calculation screens that need careful separation from Cappy's alpha coordination scope.
+- The OpenAPI contract appears referenced by documentation but still needs confirmation before a generated Swift client can be wired.
+
+## What I had to invent or assume
+
+- I created a founder-directed scaffold ticket ID because no existing Milestone 2 ticket file exists for the iOS scaffold.
+- I assumed placeholder UI copy is acceptable only for scaffolding and avoided displaying sample PHI or clinical dosing guidance.
+- I assumed the first source-only scaffold should precede creation of the Xcode project because this environment cannot run Xcode.
+
+## Tech debt or follow-ups created
+
+- High: Generate `Cappy.xcodeproj` on macOS and verify `xcodebuild -scheme Cappy build`.
+- High: Add a real Core NFC implementation and test on physical iPhone hardware with NTAG215 tags.
+- Medium: Add automated token generation from `design/tokens.json` to `Tokens.swift`.
+- Medium: Confirm or complete the OpenAPI contract before implementing networking.
+- Medium: Add XCTest and SwiftUI preview coverage for the new components.
+
+## Suggested change to my own system prompt
+
+When scaffolding mobile work in a non-macOS environment, explicitly separate source scaffolding from Xcode project generation and list the macOS verification follow-up.
+
+## Time spent
+
+Approximately 1 agent-hour.


### PR DESCRIPTION
## **User description**
### Motivation

- Provide a first native SwiftUI scaffold for the Cappy iOS app so development can begin without an Xcode project present in the repo. 
- Establish a design token bridge and a small set of reusable components to ensure consistent visuals across future screens. 
- Add a simple structured logger with safe metadata filtering to avoid accidental PHI leaks in logs. 
- Surface an initial home/dashboard feature to exercise tokens, components, and logging in a realistic layout.

### Description

- Added an app entry and dependency root with `AppEnvironment.swift`, `CappyApp.swift`, and `RootView` that use `AppEnvironment.preview` for runtime wiring. 
- Introduced a lightweight logger in `CappyLogger.swift` with `SafeLogEvent` that filters allowed metadata keys and exposes `info`/`error` helpers. 
- Implemented design tokens and helpers in `Cappy/Design/Tokens.swift` for colors, spacing, radii, typography, motion, and touch targets with color initializers. 
- Created reusable UI components and views: `CappyButton`, `CappyCard`, `ChildAvatar`, `DoseStatusPill`, and a scaffolded feature screen `HomeDashboardView`, plus resource stubs `Assets.xcassets/Contents.json` and `Localizable.strings`. 
- Updated `ios/README.md` to document the scaffold, next steps, and design token source of truth, and added a retrospective `project/retros/2026-06-30-TICKET-IOS-SCAFFOLD.md` describing assumptions and follow-ups.

### Testing

- No automated tests were executed because an Xcode project (`Cappy.xcodeproj`) is not present and this environment cannot run `xcodebuild`; build verification and XCTest coverage will run after the Xcode project is generated on macOS. 
- Static or runtime checks were not run in CI for the same reason and will be performed once the project is attached and `xcodebuild -scheme Cappy build` can be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a430ba20d148329946f860b863057f6)


___

## **CodeAnt-AI Description**
**Add the first native SwiftUI app scaffold for Cappy**

### What Changed
- Added the app entry and default home screen so the iOS app now opens into a working SwiftUI dashboard.
- Introduced shared visual building blocks for buttons, cards, avatars, and dose status labels to keep screens consistent.
- Added a design token set for colors, spacing, radii, typography, motion, and touch target size, including light and dark appearance support.
- Added a safe logger that only keeps approved metadata keys and used it from the home screen’s scan action.
- Updated the iOS README with the current scaffold structure, design source of truth, safety notes, and next setup steps.

### Impact
`✅ Faster start on native iOS screens`
`✅ Consistent shared UI across the app`
`✅ Safer logging of app events`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
